### PR TITLE
TASK: Use exposed CK api for base classes

### DIFF
--- a/Resources/Private/CustomStylingForCkEditor/src/examplePlugin.js
+++ b/Resources/Private/CustomStylingForCkEditor/src/examplePlugin.js
@@ -1,4 +1,4 @@
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import {Plugin} from 'ckeditor5-exports';
 import AttributeCommand from '@ckeditor/ckeditor5-basic-styles/src/attributecommand';
 
 export default class Example extends Plugin {


### PR DESCRIPTION
This can reduce the bundle size of custom plugins quite a lot
and solves issues when CK editor complains about duplicate
modules and plugins.